### PR TITLE
Add GPT-4 Turbo model

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
             },
             {
               "title": "GPT-4 Turbo",
-              "value": "gpt-4-1106-preview"
+              "value": "gpt-4-turbo-preview"
             }
           ]
         }
@@ -104,7 +104,7 @@
             },
             {
               "title": "GPT-4 Turbo",
-              "value": "gpt-4-1106-preview"
+              "value": "gpt-4-turbo-preview"
             }
           ]
         }
@@ -154,7 +154,7 @@
             },
             {
               "title": "GPT-4 Turbo",
-              "value": "gpt-4-1106-preview"
+              "value": "gpt-4-turbo-preview"
             }
           ]
         }
@@ -204,7 +204,7 @@
             },
             {
               "title": "GPT-4 Turbo",
-              "value": "gpt-4-1106-preview"
+              "value": "gpt-4-turbo-preview"
             }
           ]
         }
@@ -246,7 +246,7 @@
             },
             {
               "title": "GPT-4 Turbo",
-              "value": "gpt-4-1106-preview"
+              "value": "gpt-4-turbo-preview"
             }
           ]
         }
@@ -304,7 +304,7 @@
             },
             {
               "title": "GPT-4 Turbo",
-              "value": "gpt-4-1106-preview"
+              "value": "gpt-4-turbo-preview"
             }
           ]
         }
@@ -346,7 +346,7 @@
             },
             {
               "title": "GPT-4 Turbo",
-              "value": "gpt-4-1106-preview"
+              "value": "gpt-4-turbo-preview"
             }
           ]
         }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,10 @@
             {
               "title": "GPT-4 (32K, 0613)",
               "value": "gpt-4-32k-0613"
+            },
+            {
+              "title": "GPT-4 Turbo",
+              "value": "gpt-4-1106-preview"
             }
           ]
         }
@@ -97,6 +101,10 @@
             {
               "title": "GPT-4 (32K, 0613)",
               "value": "gpt-4-32k-0613"
+            },
+            {
+              "title": "GPT-4 Turbo",
+              "value": "gpt-4-1106-preview"
             }
           ]
         }
@@ -143,6 +151,10 @@
             {
               "title": "GPT-4 (32K, 0613)",
               "value": "gpt-4-32k-0613"
+            },
+            {
+              "title": "GPT-4 Turbo",
+              "value": "gpt-4-1106-preview"
             }
           ]
         }
@@ -189,6 +201,10 @@
             {
               "title": "GPT-4 (32K, 0613)",
               "value": "gpt-4-32k-0613"
+            },
+            {
+              "title": "GPT-4 Turbo",
+              "value": "gpt-4-1106-preview"
             }
           ]
         }
@@ -227,6 +243,10 @@
             {
               "title": "GPT-4 (32K, 0613)",
               "value": "gpt-4-32k-0613"
+            },
+            {
+              "title": "GPT-4 Turbo",
+              "value": "gpt-4-1106-preview"
             }
           ]
         }
@@ -281,6 +301,10 @@
             {
               "title": "GPT-4 (32K, 0613)",
               "value": "gpt-4-32k-0613"
+            },
+            {
+              "title": "GPT-4 Turbo",
+              "value": "gpt-4-1106-preview"
             }
           ]
         }
@@ -319,6 +343,10 @@
             {
               "title": "GPT-4 (32K, 0613)",
               "value": "gpt-4-32k-0613"
+            },
+            {
+              "title": "GPT-4 Turbo",
+              "value": "gpt-4-1106-preview"
             }
           ]
         }

--- a/package.json
+++ b/package.json
@@ -387,6 +387,10 @@
         {
           "title": "GPT-4 (32K, 0613)",
           "value": "gpt-4-32k-0613"
+        },
+        {
+          "title": "GPT-4 Turbo",
+          "value": "gpt-4-turbo-preview"
         }
       ],
       "required": true,

--- a/src/util.ts
+++ b/src/util.ts
@@ -36,6 +36,8 @@ export function estimatePrice(prompt_token: number, output_token: number, model:
     price = (prompt_token * 0.03 + output_token * 0.06) / 10;
   } else if (model == "gpt-4-32k-0613") {
     price = (prompt_token * 0.03 + output_token * 0.06) / 10;
+  } else if (model == "gpt-4-1106-preview") {
+    price = (prompt_token * 0.01 + output_token * 0.03) / 10;
   } else {
     return -1;
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -36,7 +36,7 @@ export function estimatePrice(prompt_token: number, output_token: number, model:
     price = (prompt_token * 0.03 + output_token * 0.06) / 10;
   } else if (model == "gpt-4-32k-0613") {
     price = (prompt_token * 0.03 + output_token * 0.06) / 10;
-  } else if (model == "gpt-4-1106-preview") {
+  } else if (model == "gpt-4-turbo-preview") {
     price = (prompt_token * 0.01 + output_token * 0.03) / 10;
   } else {
     return -1;


### PR DESCRIPTION
Hi! Thanks for making this extension. :) 

I think it would be nice to support GPT-4 Turbo, now that it's available to anybody that has access to GPT-4.
Bigger context and 3x cheaper: https://openai.com/pricing

I didn't go as far as replacing GPT-4 with it (might not be desirable for some use cases I have not thought about).